### PR TITLE
[83] Make `executeRecaptcha` ref stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const MyApp = ({ Component, pageProps }) => (
 
 | **Prop**        | **Type** | **Default** | **Required** | **Description**                                                                                                                                                  |
 | --------------- | -------- | ----------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| reCaptchaKey    | string   |             | ?           | Your reCAPTCHA key, get one from [here](https://www.google.com/recaptcha/about)                                                                                  |
+| reCaptchaKey    | string   |             | ?            | Your reCAPTCHA key, get one from [here](https://www.google.com/recaptcha/about)                                                                                  |
 | useEnterprise   | boolean  | false       |              | Set to `true` if you use [ReCaptcha Enterprise](https://cloud.google.com/recaptcha-enterprise)                                                                   |
 | useRecaptchaNet | boolean  | false       |              | Set to `true` if you want to use `recaptcha.net` to load ReCaptcha script. [docs](https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally) |
 | language        | string   |             |              | Optional [Language Code](https://developers.google.com/recaptcha/docs/language)                                                                                  |
@@ -68,6 +68,27 @@ const MyApp = ({ Component, pageProps }) => (
 You must pass `reCaptchaKey` if `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` env variable is not defined.
 
 All extra props are passed directly to the Script tag, so you can use all props from the [next/script documentation](https://nextjs.org/docs/api-reference/next/script).
+
+## Accessing global context props
+
+You can access global `grecaptcha` object, script's loading state and other props by calling `useReCaptcha` hook:
+
+```tsx
+import { useReCaptcha } from "next-recaptcha-v3";
+
+const {
+  /** reCAPTCHA_site_key */
+  reCaptchaKey,
+  /** Global ReCaptcha object */
+  grecaptcha,
+  /** Is ReCaptcha script loaded */
+  loaded,
+  /** Is ReCaptcha script failed to load */
+  error,
+  /** Other hook props */
+  ...otherProps
+} = useReCaptcha();
+```
 
 ### reCAPTCHA Enterprise
 
@@ -165,18 +186,18 @@ import { validateToken } from "./utils";
 
 interface MyPageProps extends WithReCaptchaProps {}
 
-const MyPage: React.FC<MyPageProps> = ({ executeRecaptcha }) => {
+const MyPage: React.FC<MyPageProps> = ({ loaded, executeRecaptcha }) => {
   const [token, setToken] = useState<string>(null);
 
   useEffect(() => {
-    if (typeof executeRecaptcha === "function") {
+    if (loaded) {
       const generateToken = async () => {
         const newToken = await executeRecaptcha("page-view");
         setToken(newToken);
       };
       generateToken();
     }
-  }, [executeRecaptcha]);
+  }, [loaded, executeRecaptcha]);
 
   useEffect(() => {
     if (token) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-recaptcha-v3",
-  "version": "1.1.0-canary.2",
+  "version": "1.1.0-canary.3",
   "description": "🤖 Next.js hook to add Google ReCaptcha to your application",
   "license": "MIT",
   "author": "Roman Zhuravlov",

--- a/src/ReCaptcha.tsx
+++ b/src/ReCaptcha.tsx
@@ -18,11 +18,10 @@ const ReCaptcha: React.FC<ReCaptchaProps> = ({
   validate = true,
   reCaptchaKey,
 }) => {
-  const { executeRecaptcha } = useReCaptcha(reCaptchaKey);
+  const { loaded, executeRecaptcha } = useReCaptcha(reCaptchaKey);
 
   useEffect(() => {
-    if (!validate) return;
-    if (typeof executeRecaptcha !== "function") return;
+    if (!validate || !loaded) return;
     if (typeof onValidate !== "function") return;
 
     const handleExecuteRecaptcha = async () => {
@@ -31,7 +30,7 @@ const ReCaptcha: React.FC<ReCaptchaProps> = ({
     };
 
     handleExecuteRecaptcha();
-  }, [action, onValidate, validate, executeRecaptcha]);
+  }, [action, onValidate, validate, loaded, executeRecaptcha]);
 
   return null;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { useEffect, useLayoutEffect } from "react";
+
 /**
  * Function to generate the src for the script tag
  * Refs: https://developers.google.com/recaptcha/docs/loading
@@ -22,3 +24,7 @@ export const getRecaptchaScriptSrc = ({
 
   return src;
 };
+
+// https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;


### PR DESCRIPTION
Refs #83 

⚠️ This PR might be a breaking change for some users

- Make `executeRecaptcha` function stable by wrapping `grecaptcha.execute` with `useRef`
- Update `ReCaptcha` component logic to use `loaded` prop
- Adjust `withReCaptcha` example to use `loaded` prop
- Add new section to README about global context props